### PR TITLE
fix(twitter): closing brace

### DIFF
--- a/commands/twitter/index.js
+++ b/commands/twitter/index.js
@@ -143,7 +143,7 @@ module.exports = {
 			return {
 				reply: (context.params.textOnly)
 					? links
-					: `${fixedText} ${links} (posted ${delta}}`
+					: `${fixedText} ${links} (posted ${delta})`
 			};
 		}
 		else {


### PR DESCRIPTION
The braces surrounding the `posted <date>` weren't matching.